### PR TITLE
Allow warnings as errors for the start module

### DIFF
--- a/StateCodelab/start/build.gradle
+++ b/StateCodelab/start/build.gradle
@@ -35,7 +35,6 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         useIR = true
-        allWarningsAsErrors = true
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
, so they don't block block codelab completion.