### PR TITLE
[Layouts codelab] Bump to alpha06

### DIFF
--- a/LayoutsCodelab/app/src/main/java/com/codelab/layouts/LayoutsCodelab.kt
+++ b/LayoutsCodelab/app/src/main/java/com/codelab/layouts/LayoutsCodelab.kt
@@ -17,7 +17,6 @@
 package com.codelab.layouts
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Icon
 import androidx.compose.foundation.ScrollableRow
 import androidx.compose.foundation.Text
 import androidx.compose.foundation.background
@@ -30,6 +29,7 @@ import androidx.compose.foundation.layout.preferredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
+import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold

--- a/LayoutsCodelab/build.gradle
+++ b/LayoutsCodelab/build.gradle
@@ -17,7 +17,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.0.0-alpha05'
+        compose_version = '1.0.0-alpha06'
     }
     ext.kotlin_version = "1.4.10"
     repositories {
@@ -25,7 +25,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-alpha13'
+        classpath 'com.android.tools.build:gradle:4.2.0-alpha15'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/LayoutsCodelab/gradle/wrapper/gradle-wrapper.properties
+++ b/LayoutsCodelab/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 21 10:02:20 CEST 2020
+#Thu Oct 29 00:32:29 GMT 2020
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Upgrade to AGP 4.2 alpha 15
Upgrade to Gradle 6.7
Icon migrates from androidx.compose.foundation to androidx.compose.material

ℹ️ Codelab is **already** in alpha06, not a snapshot