### PR TITLE
Fix links to codelabs in internal README files

### DIFF
--- a/BasicsCodelab/README.md
+++ b/BasicsCodelab/README.md
@@ -1,7 +1,7 @@
 # Jetpack Compose Basics Codelab
 
 This folder contains the source code for the solution of the
-[Jetpack Compose Basics codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-basics).
+[Jetpack Compose Basics codelab](https://developer.android.com/codelabs/jetpack-compose-basics).
 
 In this codelab you will go hands-on and learn the fundamentals of declarative UI and
 [Jetpack Compose](https://developer.android.com/jetpack/compose), working with state, layouts

--- a/BasicsCodelab/README.md
+++ b/BasicsCodelab/README.md
@@ -1,7 +1,7 @@
 # Jetpack Compose Basics Codelab
 
 This folder contains the source code for the solution of the
-[Jetpack Compose Basics codelab](https://codelabs.developers.google.com/codelabs/android-compose-basics).
+[Jetpack Compose Basics codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-basics).
 
 In this codelab you will go hands-on and learn the fundamentals of declarative UI and
 [Jetpack Compose](https://developer.android.com/jetpack/compose), working with state, layouts

--- a/LayoutsCodelab/README.md
+++ b/LayoutsCodelab/README.md
@@ -1,7 +1,7 @@
 # Jetpack Compose Layouts Codelab
 
 This folder contains the source code for the solution of the
-[Jetpack Compose Layouts codelab](https://codelabs.developers.google.com/codelabs/android-compose-layouts).
+[Jetpack Compose Layouts codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-layouts).
 
 In this codelab you will learn how layout works in
 [Jetpack Compose](https://developer.android.com/jetpack/compose), how to use the built-in layouts,

--- a/LayoutsCodelab/README.md
+++ b/LayoutsCodelab/README.md
@@ -1,7 +1,7 @@
 # Jetpack Compose Layouts Codelab
 
 This folder contains the source code for the solution of the
-[Jetpack Compose Layouts codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-layouts).
+[Jetpack Compose Layouts codelab](https://developer.android.com/codelabs/jetpack-compose-layouts).
 
 In this codelab you will learn how layout works in
 [Jetpack Compose](https://developer.android.com/jetpack/compose), how to use the built-in layouts,

--- a/MigrationCodelab/README.md
+++ b/MigrationCodelab/README.md
@@ -1,6 +1,6 @@
 # Migrating to Jetpack Compose
 
-This folder contains the source code for the [Migrating to Jetpack Compose codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-migration).
+This folder contains the source code for the [Migrating to Jetpack Compose codelab](https://developer.android.com/codelabs/jetpack-compose-migration).
 
 The codelab which migrates parts of [Sunflower](https://github.com/android/sunflower)'s Plant
 details screen to Jetpack Compose is built in multiple GitHub branches:
@@ -10,7 +10,7 @@ details screen to Jetpack Compose is built in multiple GitHub branches:
 
 ## Pre-requisites
 * Experience with Kotlin syntax, including lambdas.
-* Knowing the [basics of Compose](https://codelabs.developers.google.com/codelabs/jetpack-compose-basics/).
+* Knowing the [basics of Compose](https://developer.android.com/codelabs/jetpack-compose-basics/).
 
 ## Getting Started
 1. Install the latest Android Studio [canary](https://developer.android.com/studio/preview/).

--- a/MigrationCodelab/README.md
+++ b/MigrationCodelab/README.md
@@ -1,6 +1,6 @@
 # Migrating to Jetpack Compose
 
-This folder contains the source code for the "Migrating to Jetpack Compose" codelab.
+This folder contains the source code for the [Migrating to Jetpack Compose codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-migration).
 
 The codelab which migrates parts of [Sunflower](https://github.com/android/sunflower)'s Plant
 details screen to Jetpack Compose is built in multiple GitHub branches:

--- a/README.md
+++ b/README.md
@@ -11,26 +11,26 @@ For more information about Jetpack Compose, please [read the documentation](http
 
 ## 🧬 Codelabs
 
-### [Basics codelabs](https://codelabs.developers.google.com/codelabs/jetpack-compose-basics)
+### [Basics codelabs](https://developer.android.com/codelabs/jetpack-compose-basics)
 
 Go hands-on and learn the fundamentals of declarative UI, working with state, layouts and theming.
 
-### [Layouts codelabs](https://codelabs.developers.google.com/codelabs/jetpack-compose-layouts)
+### [Layouts codelabs](https://developer.android.com/codelabs/jetpack-compose-layouts)
 
 Learn how layout works in Jetpack Compose, how to use the built-in layouts,
 [modifiers](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier),
 and even building your own custom layout.
 
-### [State codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-state)
+### [State codelab](https://developer.android.com/codelabs/jetpack-compose-state)
 
 Understand patterns for working with state in a declarative world by building a Todo application.
 
-### [Theming codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-theming)
+### [Theming codelab](https://developer.android.com/codelabs/jetpack-compose-theming)
 
 Go hands on with Compose’s implementation of Material Design to understand how to theme an
 application’s colors, typography and shapes and support light and dark themes.
 
-### [Migration codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-migration)
+### [Migration codelab](https://developer.android.com/codelabs/jetpack-compose-migration)
 
 Understand how Jetpack Compose and View-based UIs can co-exist and interact, making it easy to
 adopt Compose at your own pace.

--- a/StateCodelab/README.md
+++ b/StateCodelab/README.md
@@ -1,6 +1,6 @@
 # Using State in Jetpack Compose Codelab
 
-This folder contains the source code for the [Using State in Jetpack Compose codelab](https://codelabs.developers.google.com/codelabs/android-compose-state).
+This folder contains the source code for the [Using State in Jetpack Compose codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-state).
 
 
 In this codelab, you will explore patterns for working with state in a declarative world by building a Todo application. We'll see what unidirectional

--- a/StateCodelab/README.md
+++ b/StateCodelab/README.md
@@ -1,6 +1,6 @@
 # Using State in Jetpack Compose Codelab
 
-This folder contains the source code for the [Using State in Jetpack Compose codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-state).
+This folder contains the source code for the [Using State in Jetpack Compose codelab](https://developer.android.com/codelabs/jetpack-compose-state).
 
 
 In this codelab, you will explore patterns for working with state in a declarative world by building a Todo application. We'll see what unidirectional

--- a/ThemingCodelab/README.md
+++ b/ThemingCodelab/README.md
@@ -1,6 +1,6 @@
 # Jetpack Compose Theming Codelab
 
-This folder contains the source code for the [Jetpack Compose Theming codelab](https://codelabs.developers.google.com/codelabs/android-compose-theming).
+This folder contains the source code for the [Jetpack Compose Theming codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-theming).
 
 In this codelab you will learn how to use [Jetpack Compose](https://developer.android.com/jetpack/compose)’s theming APIs to style your application. We’ll see how to customize colors, shapes and typography so that they’re used consistently throughout your application, supporting multiple themes such as light & dark theme.
 

--- a/ThemingCodelab/README.md
+++ b/ThemingCodelab/README.md
@@ -1,6 +1,6 @@
 # Jetpack Compose Theming Codelab
 
-This folder contains the source code for the [Jetpack Compose Theming codelab](https://codelabs.developers.google.com/codelabs/jetpack-compose-theming).
+This folder contains the source code for the [Jetpack Compose Theming codelab](https://developer.android.com/codelabs/jetpack-compose-theming).
 
 In this codelab you will learn how to use [Jetpack Compose](https://developer.android.com/jetpack/compose)’s theming APIs to style your application. We’ll see how to customize colors, shapes and typography so that they’re used consistently throughout your application, supporting multiple themes such as light & dark theme.
 


### PR DESCRIPTION
Links to the codelabs in the internal README for each of the samples were pointing to the wrong place resulting in a 404 error.