### PR TITLE
[Animation] Fix vertical offset event passing to external in swipeToDismiss

### DIFF
--- a/AnimationCodelab/finished/src/main/java/com/example/android/codelab/animation/ui/home/Home.kt
+++ b/AnimationCodelab/finished/src/main/java/com/example/android/codelab/animation/ui/home/Home.kt
@@ -99,6 +99,7 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.consumePositionChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
@@ -669,7 +670,6 @@ private fun TaskRow(task: String, onRemove: () -> Unit) {
         }
     }
 }
-
 /**
  * The modified element can be horizontally swiped away.
  *
@@ -695,12 +695,16 @@ private fun Modifier.swipeToDismiss(
                 // Wait for drag events.
                 awaitPointerEventScope {
                     horizontalDrag(pointerId) { change ->
+                        // Record the position after offset
+                        val horizontalDragOffset = offsetX.value + change.positionChange().x
                         launch {
                             // Overwrite the `Animatable` value while the element is dragged.
-                            offsetX.snapTo(offsetX.value + change.positionChange().x)
+                            offsetX.snapTo(horizontalDragOffset)
                         }
                         // Record the velocity of the drag.
                         velocityTracker.addPosition(change.uptimeMillis, change.position)
+                        // Consume the gesture event, not passed to external
+                        change.consumePositionChange()
                     }
                 }
                 // Dragging finished. Calculate the velocity of the fling.


### PR DESCRIPTION
Consume gesture events so that gesture events are not passed to LazyColumn.

https://user-images.githubusercontent.com/30253468/123050416-44f10980-d433-11eb-8ddd-96fe234a8a86.mp4



