### PR TITLE
Fix a build error in TestingCodeLab

### DIFF
--- a/TestingCodelab/app/src/androidTest/java/com/example/compose/rally/TopAppBarTest.kt
+++ b/TestingCodelab/app/src/androidTest/java/com/example/compose/rally/TopAppBarTest.kt
@@ -60,7 +60,7 @@ class TopAppBarTest {
 
         composeTestRule
             .onNode(
-                hasText(RallyScreen.Accounts.name.toUpperCase()) and
+                hasText(RallyScreen.Accounts.name.uppercase()) and
                     hasParent(
                         hasContentDescription(RallyScreen.Accounts.name)
                     ),


### PR DESCRIPTION
This pull request replaces the deprecated `String.toUpperCase()` with `String.uppercase()`.

Because all the warnings are treated as errors in this project, the deprecated function prevented `rallyTopAppBarTest_currentLabelExists()` from running.