### PR TITLE
[End] Fix ModalNavigationDrawer and PermanentNavigationDrawer sizing behaviors

### DIFF
--- a/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyApp.kt
+++ b/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyApp.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.PermanentDrawerSheet
 import androidx.compose.material3.PermanentNavigationDrawer
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
@@ -125,7 +126,13 @@ private fun ReplyNavigationWrapperUI(
     val selectedDestination = ReplyDestinations.INBOX
 
     if (navigationType == ReplyNavigationType.PERMANENT_NAVIGATION_DRAWER) {
-        PermanentNavigationDrawer(drawerContent = { NavigationDrawerContent(selectedDestination) }) {
+        PermanentNavigationDrawer(
+            drawerContent = {
+                PermanentDrawerSheet {
+                    NavigationDrawerContent(selectedDestination)
+                }
+            }
+        ) {
             ReplyAppContent(navigationType, contentType, replyHomeUIState)
         }
     } else {

--- a/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyApp.kt
+++ b/AdaptiveUiCodelab/app/src/main/java/com/example/reply/ui/ReplyApp.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -130,14 +131,16 @@ private fun ReplyNavigationWrapperUI(
     } else {
         ModalNavigationDrawer(
             drawerContent = {
-                NavigationDrawerContent(
-                    selectedDestination,
-                    onDrawerClicked = {
-                        scope.launch {
-                            drawerState.close()
+                ModalDrawerSheet {
+                    NavigationDrawerContent(
+                        selectedDestination,
+                        onDrawerClicked = {
+                            scope.launch {
+                                drawerState.close()
+                            }
                         }
-                    }
-                )
+                    )
+                }
             },
             drawerState = drawerState
         ) {


### PR DESCRIPTION
The width of `NavigationDrawerContent` exceeds the operational width of `ModalNavigationDrawer`'s open/close state.
The `ModalDrawerSheet` sets `minWidth` and `maxWidth` by default.

Similarly with `PermanentNavigationDrawer`, without limiting content's size it takes up the whole screen, therefore `PermanentDrawerSheet` can be used to fix the issue

EDIT (push force): To undo unnecessary format change