### PR TITLE
Wrap application in theme

### DIFF
--- a/BasicLayoutsCodelab/app/src/main/java/com/codelab/basiclayouts/MainActivity.kt
+++ b/BasicLayoutsCodelab/app/src/main/java/com/codelab/basiclayouts/MainActivity.kt
@@ -70,7 +70,10 @@ import java.util.*
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent { MySootheApp() }
+        setContent {MySootheTheme {
+        MySootheApp()
+            } 
+        }
     }
 }
 
@@ -369,5 +372,7 @@ fun BottomNavigationPreview() {
 @Preview(widthDp = 360, heightDp = 640)
 @Composable
 fun MySoothePreview() {
-    MySootheApp()
+    MySootheTheme {
+        MySootheApp()
+    }
 }


### PR DESCRIPTION
The components are distorted when the app is run on an emulator or the final preview is shown since it was not wrapped in the theme.