### PR TITLE
SingleAccountPageOpening

### DIFF
--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.compose.rally.ui.components.RallyTabRow
@@ -48,8 +49,7 @@ fun RallyApp() {
         val navController = rememberNavController()
         val currentBackStack by navController.currentBackStackEntryAsState()
         val currentDestination = currentBackStack?.destination
-        val currentScreen =
-            rallyTabRowScreens.find { it.route == currentDestination?.route } ?: Overview
+        val currentScreen = getCurrentScreen(currentDestination)
 
         Scaffold(
             topBar = {
@@ -68,4 +68,14 @@ fun RallyApp() {
             )
         }
     }
+}
+
+private fun getCurrentScreen(currentDestination: NavDestination?) : RallyDestination {
+    val currentScreen = rallyTabRowScreens.find { it.route == currentDestination?.route } ?: previousScreen
+    setLastScreen(currentScreen)
+    return currentScreen
+}
+
+private fun setLastScreen(currentScreen: RallyDestination?){
+    previousScreen = currentScreen ?: Overview
 }

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyDestinations.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyDestinations.kt
@@ -70,3 +70,4 @@ object SingleAccount : RallyDestination {
 
 // Screens to be displayed in the top RallyTabRow
 val rallyTabRowScreens = listOf(Overview, Accounts, Bills)
+var previousScreen : RallyDestination = Overview


### PR DESCRIPTION
When i try to open single account page from accounts , app bar were showed overview tab as selected. This is happening while currentdestination is comparing that does rallyTabRowScreens have the selected route. There is no route like single_account/accountType so it shows overview tab as selected. If we hold last selected tab like previousScreen , while we try to open singleAccount page from accounts tab , it shows accounts page as selected even there is no route in rallyTabRowScreens.