### PR TITLE
[AdvancedStateAndSideEffectsCodelab][main] Update Kotlin and Kotlin Compose Compiler 

### DIFF
--- a/AdvancedStateAndSideEffectsCodelab/app/build.gradle
+++ b/AdvancedStateAndSideEffectsCodelab/app/build.gradle
@@ -83,7 +83,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion "1.3.2"
+        kotlinCompilerExtensionVersion "1.4.2"
     }
 
     packagingOptions {

--- a/AdvancedStateAndSideEffectsCodelab/build.gradle
+++ b/AdvancedStateAndSideEffectsCodelab/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.4.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
         classpath "com.google.dagger:hilt-android-gradle-plugin:2.44.2"
     }
 }


### PR DESCRIPTION
This change is needed to to meet the requirements for the latest lifecycle-runtime-compose 2.6.0+ dependency needed for step 4 - otherwise the build will break when the dependency is added.