### PR TITLE
Add window size class dependency in solution for AdaptiveUICodelab

### DIFF
--- a/AdaptiveUiCodelab/app/build.gradle
+++ b/AdaptiveUiCodelab/app/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation "androidx.window:window:1.0.0"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
+    implementation "androidx.compose.material3:material3-window-size-class:1.2.0-alpha01"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'


### PR DESCRIPTION
Add missing `material3-window-size-class` dependency in solution code for 'Build adaptive apps with Jetpack Compose'.