### PR TITLE
Reduce AccelerateHeavyScreenBenchmark variance

### DIFF
--- a/PerformanceCodelab/measure/src/main/java/com/compose/performance/measure/AbstractBenchmark.kt
+++ b/PerformanceCodelab/measure/src/main/java/com/compose/performance/measure/AbstractBenchmark.kt
@@ -23,11 +23,11 @@ import androidx.benchmark.macro.junit4.MacrobenchmarkRule
 import org.junit.Rule
 
 abstract class AbstractBenchmark(
-    protected val startupMode: StartupMode = StartupMode.WARM,
-    // For the purpose of this workshop, we have iterations set to low number.
-    // For more accurate measurements, you should increase the iterations to at least 10
-    // based on how much variance occurs in the results. In general more iterations = more stable
-    // results, but longer execution time.
+    protected val startupMode: StartupMode? = StartupMode.WARM,
+    // For accurate measurements, you should set the iterations to at least 10, based on how much
+    // variance occurs in the results. In general more iterations = more stable
+    // results, but longer execution time. For exploration purposes you could set
+    // iterations to 1.
     protected val iterations: Int = 1
 ) {
     @get:Rule


### PR DESCRIPTION
- Increased iterations from 1 to 10 for more realistic results, in line with the spirit of the performance codelab.
- Updated the measure block to only include frames from scrolling, removing: 1) frames from the cold startup of the activity and 2) frames from the initial faked load delay of 500 ms.
- Added a warmup iteration that triggers loading of images.
- The 500 ms wait wasn't enough for the drag to settle, so we were potentially starting the second drag before the first had settled, and then ending the measure too early. Bumped the wait to 1000 ms, traces now show a clear ~200 ms gaps with no frames.

Note: this commit also needs to be cherry picked on the `end` branch.

<img width="1491" height="595" alt="image" src="https://github.com/user-attachments/assets/d778a1cb-0afa-4667-9a9c-ff5dcb929246" />
